### PR TITLE
Fix LocaNMF symbol export

### DIFF
--- a/locanmf/LocaNMF.py
+++ b/locanmf/LocaNMF.py
@@ -16,6 +16,19 @@ from .video import LowRankVideo
 from .demix import HalsNMF
 from .demix import LocalizedNMF
 
+__all__ = [
+    "adaptive_fit",
+    "extract_region_metadata",
+    "factor_region_videos",
+    "rank_linesearch",
+    "init_from_low_rank_video",
+    "evaluate_fit_to_region",
+    "lambda_linesearch",
+    "hals",
+    "version",
+    "LocaNMF",
+]
+
 
 def adaptive_fit(video_mats,
                  valid_mask,
@@ -591,4 +604,7 @@ def version():
     print('version = 1.1')
 
 # for backward-compatibility / external import
-LocaNMF = LocalizedNMF
+class LocaNMF(LocalizedNMF):
+    """Backwards-compatible alias for :class:`LocalizedNMF`."""
+    pass
+


### PR DESCRIPTION
## Summary
- expose public names from `locanmf/LocaNMF.py`
- provide explicit `LocaNMF` class alias for documentation and imports

## Testing
- `python -m py_compile locanmf/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68823e74ebf8832dabbd0cb61e0da1a5