### PR TITLE
Fix LocaNMF module import

### DIFF
--- a/locanmf/LocaNMF.py
+++ b/locanmf/LocaNMF.py
@@ -16,6 +16,19 @@ from .video import LowRankVideo
 from .demix import HalsNMF
 from .demix import LocalizedNMF
 
+__all__ = [
+    "adaptive_fit",
+    "extract_region_metadata",
+    "factor_region_videos",
+    "rank_linesearch",
+    "init_from_low_rank_video",
+    "evaluate_fit_to_region",
+    "lambda_linesearch",
+    "hals",
+    "version",
+    "LocaNMF",
+]
+
 
 def adaptive_fit(video_mats,
                  valid_mask,
@@ -592,3 +605,4 @@ def version():
 
 # for backward-compatibility / external import
 LocaNMF = LocalizedNMF
+

--- a/locanmf/__init__.py
+++ b/locanmf/__init__.py
@@ -10,4 +10,4 @@ DEFAULT_DEVICE = (
     "cpu"
 )
 
-from .LocaNMF import LocaNMF
+from . import LocaNMF


### PR DESCRIPTION
## Summary
- keep `LocaNMF` as a module by importing it in `__init__`
- restore old alias for backwards compatibility

## Testing
- `python -m py_compile locanmf/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68823e74ebf8832dabbd0cb61e0da1a5